### PR TITLE
Use version-sort for kernel images

### DIFF
--- a/uefi-mkconfig
+++ b/uefi-mkconfig
@@ -236,7 +236,7 @@ main () {
 
 		# Find all .efi files on this partition
 		partition_efis="$(find "$partition_mount" \( -name "vmlinuz-*.efi" -o -name "vmlinux-*.efi" -o -name "gentoo-*.efi"\
-		-o -name "kernel-*.efi" -o -name "bzImage*.efi" -o -name "zImage*.efi" -o -name "vmlinuz.efi" \) | sort -r)"
+		-o -name "kernel-*.efi" -o -name "bzImage*.efi" -o -name "zImage*.efi" -o -name "vmlinuz.efi" \) | sort -V)"
 		
 		# Remove invalid entries
 		remove_uefi_entries


### PR DESCRIPTION
Regular sort works correctly only for versions with the same amount of digits in each segment. Using -V parameter ensures that versions are sorted numerically, which is more appropriate for kernel images.

For example:
```sh
$ echo kernel-6.7.{8..11}.efi | xargs -n1 | sort -r
kernel-6.7.9.efi
kernel-6.7.8.efi
kernel-6.7.11.efi
kernel-6.7.10.efi

$ echo kernel-6.7.{8..11}.efi | xargs -n1 | sort -rV
kernel-6.7.11.efi
kernel-6.7.10.efi
kernel-6.7.9.efi
kernel-6.7.8.efi
```