### PR TITLE
Replace entire entry deletion logic with a simple wipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Please don't insert `initrd=` into kernel commands manually. It will be discarde
 
 Uefi-mkconfig can autodiscover and add microcode image to the uefi entry.
 For this to happen the microcode image needs to be present in the same directory as kernel images.
+
 If needed, microcode image can be ignored by creating empty file named the same way with the suffix .ignore 
 
 ```
@@ -42,6 +43,7 @@ For now, if SHIM booting is needed, kernel and shim have to be present within di
 ## Custom/Managed entries
 
 Script will create and delete **ONLY** EFI entries with hex ID larger or equal to 0100 and less or equal to 0200.
+ID 0200 is dedicated for automatic backup entry creation. This entry will not be deleted automatically!
 If custom entry is needed, assign it hex ID below or above this range.
 
 ## Kernel Commands
@@ -64,8 +66,6 @@ Example:
 machine1 ~ # cat /etc/default/uefi-mkconfig
 crypt_root=UUID=dcb0cc6f-ddac-ge38-b92c-e59edc55dv61 root=/dev/mapper/gentoo rootfstype=ext4 resume=/dev/mapper/swap dolvm quiet
 ```
-
-If configuration file containing kernel commands has been modified, uefi-mkconfig **will regenerate all its managed entries**.
 
 ## Entry labeling
 
@@ -95,6 +95,32 @@ drwxr-xr-x 3 root root     4096 Apr  4 10:15 ..
 ```
 
 WARNING: If uefi entry was already created by uefi-mkconfig for this kernel before `.ignore` file creation. **Its uefi entry will be deleted!**
+
+## Backup UEFI entry creation
+
+uefi-mkconfig can automatically create backup uefi entry at position 0200.
+This entry **will not** be automatically deleted and **will not** be added to the bootorder.
+Besides these two special rules, the entry creation itself is identical to the normal processs.
+
+**Only one kernel image** can be designated as backup. If multiple one are marked as backup, kernel of the most recent version is chosen.
+
+To designate kernel image as backup, create an empty file in the same directory as the kernel image itsel, name it the same way but add suffix ".uefibackup"
+
+Example:
+```
+user@machine1:~:$ ls -la /boot/EFI/Gentoo/
+total 236336
+drwxr-xr-x 2 root root     8192 Jun 28 10:56 .
+drwxr-xr-x 3 root root     4096 Apr  4 10:15 ..
+-rwxr-xr-x 1 root root   274097 Jun 17 10:17 config-6.9.5-gentoo-dist
+-rwxr-xr-x 1 root root   274097 Jun 24 13:57 config-6.9.6-gentoo-dist
+-rwxr-xr-x 1 root root 17661133 Jun 17 10:17 initramfs-6.9.5-gentoo-dist.img
+-rwxr-xr-x 1 root root 17662709 Jun 24 13:57 initramfs-6.9.6-gentoo-dist.img
+-rwxr-xr-x 1 root root 17144816 Jun 17 10:17 vmlinuz-6.9.5-gentoo-dist.efi
+-rwxr-xr-x 1 root root 17144816 Jun 24 13:57 vmlinuz-6.9.6-gentoo-dist.efi
+-rwxr-xr-x 1 root root        0 Jun 28 10:56 vmlinuz-6.9.6-gentoo-dist.efi.uefibackup
+```
+
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ WARNING: If uefi entry was already created by uefi-mkconfig for this kernel befo
 
 ## Backup UEFI entry creation
 
-uefi-mkconfig can automatically create backup uefi entry at position 0200.
+uefi-mkconfig can automatically create backup uefi entry at position 0100.
 This entry **will not** be automatically deleted and **will not** be added to the bootorder.
 Besides these two special rules, the entry creation itself is identical to the normal processs.
 
@@ -120,6 +120,8 @@ drwxr-xr-x 3 root root     4096 Apr  4 10:15 ..
 -rwxr-xr-x 1 root root 17144816 Jun 24 13:57 vmlinuz-6.9.6-gentoo-dist.efi
 -rwxr-xr-x 1 root root        0 Jun 28 10:56 vmlinuz-6.9.6-gentoo-dist.efi.uefibackup
 ```
+
+This backup entry will be marked by UMCB string in the label entry
 
 
 ## Troubleshooting

--- a/uefi-mkconfig
+++ b/uefi-mkconfig
@@ -13,34 +13,6 @@ ewarn() {
 	echo -e " ${NOCOLOR-\e[1;33m*\e[0m }${*}" >&2
 }
 
-check_if_uefi_entry_exists () {
-	local IFS=$'\n'
-	local efi_file_path_check
-	efi_file_path_check="${efi_file_path//\//\\}"
-
-	for entry in $(efibootmgr -u); do
-		# Added last case because while testing this script I found that sometimes, firmware uppercases the path and reverts backslash to forward slash
-		if [[ "$entry" == *"$partition_partuuid"* ]]; then
-			if [[ "$entry" == *"(${efi_file_path_check}"* ]] || [[ "$entry" == *"(${efi_file_path_check^^}"* ]]; then
-	
-				# Get Hex number of a entry
-				uefi_entry_hex="${entry:4:4}"
-				return 0
-
-			# Added for handling shim entries
-			elif [[ "$entry" ==  *"(.${efi_file_path_check}"* ]] || [[ "$entry" ==  *"(.${efi_file_path_check^^}"* ]]; then
-		
-				# Get Hex number of a entry
-				uefi_entry_hex="${entry:4:4}"
-				return 0
-	
-			fi
-		fi
-			
-	done
-	return 1
-}
-
 add_uefi_entries () (
 	for efi_file in $partition_efis; do
 		# Skip this kernel if ignore file is found
@@ -53,156 +25,86 @@ add_uefi_entries () (
 		local efi_file_path
 		efi_file_path="${efi_file//$partition_mount}"
 
-		# Add entry if it doesn't exist
-		if ! check_if_uefi_entry_exists; then
+		# Find first free hex address larger than or equal to 0100 for new UEFI boot entry
+		local bootnum
+		bootnum=256 # 256 is decimal value of 0100
+		while [[ "$(efibootmgr -u)" == *"Boot$(printf %04X $bootnum)"* ]]; do
+			bootnum=$((bootnum + 1))
+			
+			# Die if script exceeds managed range 0100-0200
+			if [[ $bootnum -gt 512 ]]; then
+				die "All IDs, within managed range by uefi-mkconfig, are full!"
+			fi
+
+		done
 		
-			# Find first free hex address larger than or equal to 0100 for new UEFI boot entry
-			local bootnum
-			bootnum=256 # 256 is decimal value of 0100
-			while [[ "$(efibootmgr -u)" == *"Boot$(printf %04X $bootnum)"* ]]; do
-				bootnum=$((bootnum + 1))
-				
-				# Die if script exceeds managed range 0100-0200
-				if [[ $bootnum -gt 512 ]]; then
-					die "All IDs, within managed range by uefi-mkconfig, are full!"
-				fi
+		# Convert chosen entry ID into hex
+		bootnum="$(printf %04X $bootnum)"
 
-			done
-			
-			# Convert chosen entry ID into hex
-			bootnum="$(printf %04X $bootnum)"
-
-			# Get kernel version
-			## Remove everything before /
-			local kernel_version
-			kernel_version="${efi_file_path//*\//}"
-			## Remove everything before first - to remove any prefixes
-			kernel_version="${kernel_version/${kernel_version%%-*}-/}"
-			## Remove .efi suffix if it exists
-			if [[ "$kernel_version" == *".efi"* ]]; then
-				kernel_version="${kernel_version/\.${kernel_version##*.}}"
-			fi
-
-			# Create label for UEFI eintry
-			local partition_label
-			local entry_label
-			partition_label="$(lsblk "/dev/$partition" -lno PARTLABEL)"
-			if [[ -n ${partition_label} ]]; then
-				entry_label="$kernel_version-$partition_label"
-			else
-				entry_label="$kernel_version"
-			fi
-			
-			# Create path to initramfs
-			local initramfs_image
-			initramfs_image="${efi_file_path/${efi_file_path##*/}}initramfs-$kernel_version.img"
-			## Add .old suffix to initramfs in case we are handling kernel with -old suffix
-			[[ "$efi_file_path" == *"-old."* ]] && initramfs_image="${initramfs_image/-old}.old"
-
-			# If shim is present in directory, presume it's used for every kernel in said directory
-			local shim
-			local adding_kernel_commands
-			shim="$(find "$partition_mount""${efi_file_path/${efi_file_path##*/}/}" -maxdepth 1 -iname "*shim*.efi")"
-			if [[ -n "$shim" ]]; then
-				shim="${shim%%.efi*}.efi"
-				adding_kernel_commands="${efi_file_path//\//\\} ${kernel_commands}"
-				ewarn "Creating UEFI entry \"$bootnum\" for \"$partition_mount$efi_file_path\" using shim \"$shim\" found on \"$partition\"..."
-				efi_file_path="${efi_file_path/${efi_file_path##*/}/}${shim/*\//}"
-			else
-				adding_kernel_commands="${kernel_commands}"
-				ewarn "Creating UEFI entry \"$bootnum\" for \"$partition_mount$efi_file_path\" found on \"$partition\"..."
-			fi
-			
-			# Check if microcode image exists
-			## microcode image can be ignored the same way as kernel image via .ignore suffix
-			local microcode_path
-			microcode_path="${efi_file_path/${efi_file_path##*/}}"
-			if [[ -f "${partition_mount}${microcode_path}amd-uc.img" ]] && [[ ! -f "${partition_mount}${microcode_path}amd-uc.img.ignore" ]]; then
-				adding_kernel_commands="${adding_kernel_commands} initrd=${microcode_path//\//\\}amd-uc.img"
-			fi
-			if [[ -f "${partition_mount}${microcode_path}intel-uc.img" ]] && [[ ! -f "${partition_mount}${microcode_path}intel-uc.img.ignore" ]]; then
-				adding_kernel_commands="${adding_kernel_commands} initrd=${microcode_path//\//\\}intel-uc.img"
-			fi
-
-			# Check if corresponding initramfs exists
-			if [[ -f "$partition_mount$initramfs_image" ]]; then
-				adding_kernel_commands="${adding_kernel_commands} initrd=${initramfs_image//\//\\}"
-			else
-				ewarn "No initramfs found for \"$partition_mount$efi_file_path\"."
-			fi
-
-			# Add new entry
-			efibootmgr --create -b "$bootnum" --disk /dev/"$partition" --label "$entry_label" --loader "${efi_file_path//\//\\}"\
-			-u "$adding_kernel_commands" &>/dev/null || die "Failed to add UEFI entry for \"$efi_file_path\""
-			
-		else
-		
-			einfo "Existing UEFI Entry \"$uefi_entry_hex\" for \"$partition_mount$efi_file_path\" from partition \"$partition\" has been found."
-		
+		# Get kernel version
+		## Remove everything before /
+		local kernel_version
+		kernel_version="${efi_file_path//*\//}"
+		## Remove everything before first - to remove any prefixes
+		kernel_version="${kernel_version/${kernel_version%%-*}-/}"
+		## Remove .efi suffix if it exists
+		if [[ "$kernel_version" == *".efi"* ]]; then
+			kernel_version="${kernel_version/\.${kernel_version##*.}}"
 		fi
+
+		# Create label for UEFI eintry
+		local partition_label
+		local entry_label
+		partition_label="$(lsblk "/dev/$partition" -lno PARTLABEL)"
+		if [[ -n ${partition_label} ]]; then
+			entry_label="$kernel_version-$partition_label"
+		else
+			entry_label="$kernel_version"
+		fi
+			
+		# Create path to initramfs
+		local initramfs_image
+		initramfs_image="${efi_file_path/${efi_file_path##*/}}initramfs-$kernel_version.img"
+		## Add .old suffix to initramfs in case we are handling kernel with -old suffix
+		[[ "$efi_file_path" == *"-old."* ]] && initramfs_image="${initramfs_image/-old}.old"
+
+		# If shim is present in directory, presume it's used for every kernel in said directory
+		local shim
+		local adding_kernel_commands
+		shim="$(find "$partition_mount""${efi_file_path/${efi_file_path##*/}/}" -maxdepth 1 -iname "*shim*.efi")"
+		if [[ -n "$shim" ]]; then
+			shim="${shim%%.efi*}.efi"
+			adding_kernel_commands="${efi_file_path//\//\\} ${kernel_commands}"
+			ewarn "Creating UEFI entry \"$bootnum\" for \"$partition_mount$efi_file_path\" using shim \"$shim\" found on \"$partition\"..."
+			efi_file_path="${efi_file_path/${efi_file_path##*/}/}${shim/*\//}"
+		else
+			adding_kernel_commands="${kernel_commands}"
+			ewarn "Creating UEFI entry \"$bootnum\" for \"$partition_mount$efi_file_path\" found on \"$partition\"..."
+		fi
+			
+		# Check if microcode image exists
+		## microcode image can be ignored the same way as kernel image via .ignore suffix
+		local microcode_path
+		microcode_path="${efi_file_path/${efi_file_path##*/}}"
+		if [[ -f "${partition_mount}${microcode_path}amd-uc.img" ]] && [[ ! -f "${partition_mount}${microcode_path}amd-uc.img.ignore" ]]; then
+			adding_kernel_commands="${adding_kernel_commands} initrd=${microcode_path//\//\\}amd-uc.img"
+		fi
+		if [[ -f "${partition_mount}${microcode_path}intel-uc.img" ]] && [[ ! -f "${partition_mount}${microcode_path}intel-uc.img.ignore" ]]; then
+			adding_kernel_commands="${adding_kernel_commands} initrd=${microcode_path//\//\\}intel-uc.img"
+		fi
+
+		# Check if corresponding initramfs exists
+		if [[ -f "$partition_mount$initramfs_image" ]]; then
+			adding_kernel_commands="${adding_kernel_commands} initrd=${initramfs_image//\//\\}"
+		else
+			ewarn "No initramfs found for \"$partition_mount$efi_file_path\"."
+		fi
+
+		# Add new entry
+		efibootmgr --create -b "$bootnum" --disk /dev/"$partition" --label "$entry_label" --loader "${efi_file_path//\//\\}"\
+		-u "$adding_kernel_commands" &>/dev/null || die "Failed to add UEFI entry for \"$efi_file_path\""
 	done
 )
-
-remove_uefi_entries () {
-	local IFS=$'\n'		
-	for entry in $(efibootmgr -u | grep "$partition_partuuid"); do
-
-		# Get Hex number of a entry
-		local uefi_entry_hex
-		uefi_entry_hex="${entry:4:4}"
-		
-		# Check if the entry is within range managed by uefi-mkconfig
-		if [[ $((16#$uefi_entry_hex)) -gt 255 ]] && [[ $((16#$uefi_entry_hex)) -lt 513 ]]; then
-
-			local entry_efi_path
-			local entry_kernel_commands
-
-			# Create path to efi file
-			## Decide if entry is shim entry or not
-			if [[ "$entry" ==  *"File("*"shim"*")"* ]] || [[ "$entry" ==  *"File("*"SHIM"*")"* ]]; then
-				### Remove everything after and included with last character )
-				entry_efi_path="${entry##*(\.}"
-				### Remove everything after and included with last space
-				entry_efi_path="${entry_efi_path%%\ *}"
-				
-				### Prepare Entry kernel commands in case of shim booting
-				entry_kernel_commands=${entry##*\.efi}
-				entry_kernel_commands=${entry_kernel_commands//)*}
-				entry_kernel_commands=${entry_kernel_commands/#\ }
-			else
-				### Remove everything before first mention of string File(
-				entry_efi_path="${entry/${entry%%File(*}File\(/}"
-				### Remove everything after first ) character
-				entry_efi_path="${entry_efi_path%%)*}"
-
-				### Prepare Entry kernel commands
-				entry_kernel_commands=${entry/#*\.efi)}
-			fi
-			
-			# Remove initramfs entry from the kernel commands
-			entry_kernel_commands=${entry_kernel_commands// initrd*}
-	
-			# Check if efi file exists and if this entry in in managed range	
-			if [ ! -f "$partition_mount${entry_efi_path//\\/\/}" ] || [ -f "$partition_mount${entry_efi_path//\\/\/}.ignore" ]; then
-				
-				# Delete entry
-				ewarn "Deleting UEFI entry \"$uefi_entry_hex\"! Its EFI file \"$partition_mount${entry_efi_path//\\/\/}\" wasn't found."
-				efibootmgr -q -B -b "$uefi_entry_hex" || die "Failed to delete entry \"$uefi_entry_hex\""
-			
-			# Delete entry if kernel commands are not the same as in config file. Don't do this if kernel commands are taken from /proc/cmdline
-			elif [[ "$kernel_commands" != "$entry_kernel_commands" ]] && [[ -z $proc_kernel_commands ]]; then
-				
-				# Delete entry for regeneration
-				ewarn "Deleting UEFI entry \"$uefi_entry_hex\" for regeneration! Kernel commads in configuration differ from the ones in this entry."
-				efibootmgr -q -B -b "$uefi_entry_hex" || die "Failed to delete entry \"$uefi_entry_hex\""
-	
-			fi
-	
-		fi
-
-	done
-
-}
 
 main () {
 	efi_parttype="c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
@@ -293,12 +195,16 @@ main () {
         		partition_efis+="$(find "$partition_mount" -name "$kernel_image") "
 		done
 		
-		# Remove invalid entries
-		remove_uefi_entries
+		# Clear old entries for regeneration
+		for entry_number in {100..200}; do
+			efibootmgr -B -b $entry_number &> /dev/null
+		done
 
 		# Add missiong efi entries for efi files that exist
 		add_uefi_entries	
 	done
+
+	einfo "Done"
 
 }
 

--- a/uefi-mkconfig
+++ b/uefi-mkconfig
@@ -57,9 +57,15 @@ add_uefi_entries () (
 		local entry_label
 		partition_label="$(lsblk "/dev/$partition" -lno PARTLABEL)"
 		if [[ -n ${partition_label} ]]; then
-			entry_label="$kernel_version-$partition_label"
+			entry_label="$kernel_version on $partition_label"
 		else
 			entry_label="$kernel_version"
+		fi
+
+		if [[ -n $backup_efi ]]; then
+			entry_label="UMCB $entry_label"
+		else
+			entry_label="UMC $entry_label"
 		fi
 			
 		# Create path to initramfs
@@ -79,7 +85,7 @@ add_uefi_entries () (
 			efi_file_path="${efi_file_path/${efi_file_path##*/}/}${shim/*\//}"
 		elif [[ -n $backup_efi ]]; then
 			adding_kernel_commands="${kernel_commands}"
-			einfo "Creating BACKUP UEFI entry \"$bootnum\" for \"$partition_mount$efi_file_path\" found on \"$partition\"..."	
+			einfo "Creating BACKUP UEFI entry \"0100\" for \"$partition_mount$efi_file_path\" found on \"$partition\"..."	
 		else
 			adding_kernel_commands="${kernel_commands}"
 			einfo "Creating UEFI entry \"$bootnum\" for \"$partition_mount$efi_file_path\" found on \"$partition\"..."
@@ -104,12 +110,12 @@ add_uefi_entries () (
 		fi
 
 		# Add new entry
-		if [[ ! -n $backup_efi ]]; then
-			efibootmgr --create -b "$bootnum" --disk /dev/"$partition" --label "$entry_label" --loader "${efi_file_path//\//\\}"\
-			-u "$adding_kernel_commands" &>/dev/null || die "Failed to add UEFI entry for \"$efi_file_path\""
+		if [[ -z $backup_efi ]]; then
+			efibootmgr -q --create -b "$bootnum" --disk /dev/"$partition" --label "$entry_label" --loader "${efi_file_path//\//\\}"\
+			-u "$adding_kernel_commands" || die "Failed to add UEFI entry for \"$efi_file_path\""
 		else
-			efibootmgr --create-only -b "0200" --disk /dev/"$partition" --label "$entry_label" --loader "${efi_file_path//\//\\}"\
-			-u "$adding_kernel_commands" &>/dev/null || die "Failed to add UEFI entry for \"$efi_file_path\""
+			efibootmgr -q --create-only -b "0100" --disk /dev/"$partition" --label "$entry_label" --loader "${efi_file_path//\//\\}"\
+			-u "$adding_kernel_commands" || die "Failed to add UEFI entry for \"$efi_file_path\""
 		fi
 	done
 )
@@ -118,7 +124,7 @@ backup_entry () {
 	backup_efi=
 
 	# Check if backup entry exist at ID 200
-	if [[ "" == "$(efibootmgr -u | grep "Boot0200")" ]]; then
+	if [[ "" == "$(efibootmgr -u | grep "Boot0100")" ]]; then
 		for efi_file in $partition_efis; do	
 			# Check if file marking backup kernel image exists
 			if [[ -f "${efi_file}.uefibackup" ]]; then 
@@ -130,11 +136,12 @@ backup_entry () {
 		if [[ -n $backup_efi ]]; then 
 			partition_efis="$backup_efi"
 			add_uefi_entries
+			backup_efi=
 		else
 			ewarn "No backup kernel image designated!"
 		fi
 	else
-		einfo "Backup UEFI entry found at 0200"
+		einfo "Backup UEFI entry found at 0100"
 	fi
 }
 
@@ -201,6 +208,15 @@ main () {
 	kernel_commands="$strip_kernel_commands"
 
         [[ -z $valid_kernel_commands ]] && ewarn "Warning, kernel command \"root=\" is missing from loaded configuration!"
+		
+	# Clear old entries for regeneration
+	## 256..512 is because entry IDs are actually in hexadecimal format
+	for entry_number in {256..512}; do
+		# Wipe only boot entries with UMC stamp
+		if [[ "$(efibootmgr -u | grep Boot$(printf %04X $entry_number))" == *"UMC "* ]]; then
+			efibootmgr -q -B -b $(printf %04X $entry_number)
+		fi
+	done
 
 	for partition in $mounted_efi_partitions; do
 		
@@ -224,20 +240,17 @@ main () {
 
 		# Add path back to the kernel image
 		for kernel_image in $kernel_images; do
-        		partition_efis+="$(find "$partition_mount" -name "$kernel_image") "
+        		partition_efis_main+="$(find "$partition_mount" -name "$kernel_image") "
 		done
 		
-		# Clear old entries for regeneration
-		for entry_number in {100..199}; do
-			efibootmgr -B -b $entry_number &> /dev/null
-		done
-
-		# Add missiong efi entries for efi files that exist
-		add_uefi_entries	
-
 		# Create backup entry if it does not exist
+		partition_efis=$partition_efis_main
 		backup_entry
 		
+		# Add missiong efi entries for efi files that exist
+		partition_efis=$partition_efis_main
+		add_uefi_entries	
+
 	done
 
 	einfo "Done"

--- a/uefi-mkconfig
+++ b/uefi-mkconfig
@@ -75,11 +75,14 @@ add_uefi_entries () (
 		if [[ -n "$shim" ]]; then
 			shim="${shim%%.efi*}.efi"
 			adding_kernel_commands="${efi_file_path//\//\\} ${kernel_commands}"
-			ewarn "Creating UEFI entry \"$bootnum\" for \"$partition_mount$efi_file_path\" using shim \"$shim\" found on \"$partition\"..."
+			einfo "Creating UEFI entry \"$bootnum\" for \"$partition_mount$efi_file_path\" using shim \"$shim\" found on \"$partition\"..."
 			efi_file_path="${efi_file_path/${efi_file_path##*/}/}${shim/*\//}"
+		elif [[ -n $backup_efi ]]; then
+			adding_kernel_commands="${kernel_commands}"
+			einfo "Creating BACKUP UEFI entry \"$bootnum\" for \"$partition_mount$efi_file_path\" found on \"$partition\"..."	
 		else
 			adding_kernel_commands="${kernel_commands}"
-			ewarn "Creating UEFI entry \"$bootnum\" for \"$partition_mount$efi_file_path\" found on \"$partition\"..."
+			einfo "Creating UEFI entry \"$bootnum\" for \"$partition_mount$efi_file_path\" found on \"$partition\"..."
 		fi
 			
 		# Check if microcode image exists
@@ -101,10 +104,39 @@ add_uefi_entries () (
 		fi
 
 		# Add new entry
-		efibootmgr --create -b "$bootnum" --disk /dev/"$partition" --label "$entry_label" --loader "${efi_file_path//\//\\}"\
-		-u "$adding_kernel_commands" &>/dev/null || die "Failed to add UEFI entry for \"$efi_file_path\""
+		if [[ ! -n $backup_efi ]]; then
+			efibootmgr --create -b "$bootnum" --disk /dev/"$partition" --label "$entry_label" --loader "${efi_file_path//\//\\}"\
+			-u "$adding_kernel_commands" &>/dev/null || die "Failed to add UEFI entry for \"$efi_file_path\""
+		else
+			efibootmgr --create-only -b "0200" --disk /dev/"$partition" --label "$entry_label" --loader "${efi_file_path//\//\\}"\
+			-u "$adding_kernel_commands" &>/dev/null || die "Failed to add UEFI entry for \"$efi_file_path\""
+		fi
 	done
 )
+
+backup_entry () {
+	backup_efi=
+
+	# Check if backup entry exist at ID 200
+	if [[ "" == "$(efibootmgr -u | grep "Boot0200")" ]]; then
+		for efi_file in $partition_efis; do	
+			# Check if file marking backup kernel image exists
+			if [[ -f "${efi_file}.uefibackup" ]]; then 
+				backup_efi="$efi_file"
+			fi
+		done
+
+		# Create backup entry from the most recent kernel image with backup file mark
+		if [[ -n $backup_efi ]]; then 
+			partition_efis="$backup_efi"
+			add_uefi_entries
+		else
+			ewarn "No backup kernel image designated!"
+		fi
+	else
+		einfo "Backup UEFI entry found at 0200"
+	fi
+}
 
 main () {
 	efi_parttype="c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
@@ -196,12 +228,16 @@ main () {
 		done
 		
 		# Clear old entries for regeneration
-		for entry_number in {100..200}; do
+		for entry_number in {100..199}; do
 			efibootmgr -B -b $entry_number &> /dev/null
 		done
 
 		# Add missiong efi entries for efi files that exist
 		add_uefi_entries	
+
+		# Create backup entry if it does not exist
+		backup_entry
+		
 	done
 
 	einfo "Done"


### PR DESCRIPTION
Well this was a surprising realization. 1/3 of the code, entire logic for choosing what to delete is useless and I was able to delete it.

The only thing that changed by this is that all uefi entries within our managed range are regenerated every time uefi-mkconfig is ran.

This even fixes the issue from #5 