### PR TITLE
Fix EFI entry duplication

### DIFF
--- a/uefi-mkconfig
+++ b/uefi-mkconfig
@@ -219,7 +219,10 @@ main () {
 	done
 
 	for partition in $mounted_efi_partitions; do
-		
+
+                kernel_images=()
+                partition_efis=()
+
 		# Find partition uuid
 		partition_partuuid=$(lsblk "/dev/$partition" -lno PARTUUID)
 


### PR DESCRIPTION
Fix EFI entry duplication on systems having more than one boot drive and partition