### PR TITLE
parse uefi-label to allow the user to define a custom label

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ The configuration file should be an ordinary text file named `uefi-mkconfig` loc
 * `/etc/kernel/`,
 * `/usr/lib/kernel/`.
 
-### 4. Add kernel commands
+### 4. Add configuration options
+
+# uefi-mkconfig
 This configuration file should contain **only** space separated list of kernel commands which should be used for creating UEFI booting entries.
 For example:
 
@@ -59,6 +61,13 @@ crypt_root=UUID=dcb0cc6f-ddac-ge38-b92c-e59edc55dv61 root=/dev/mapper/gentoo roo
 ```
 
 In case this configuration file doesn't exist, uefi-mkconfig will refuse to run.
+
+# uefi-labl
+A custom label that will be used for the efi entry
+```console
+# cat /etc/default/uefi-label
+MyLinuxInstall
+```
 
 ### 5. Add all EFI partitions to fstab
 uefi-mkconfig autodiscovers kernel images by searching all mounted EFI partitions.

--- a/uefi-mkconfig
+++ b/uefi-mkconfig
@@ -15,15 +15,33 @@ ewarn() {
 
 add_uefi_entry () (
 	# Create label for UEFI entry
-	local entry_label
-	entry_label="${efi_file_path/.uefibackup} on $partition_label "
-
-	# Add prefix to entry label for easier identification
-	if [[ -n $backup_efi ]]; then
-		entry_label="UMCB $entry_label"
+	if [[ -n "${INSTALLKERNEL_CONF_ROOT}" ]]; then
+		if [[ -f "${INSTALLKERNEL_CONF_ROOT}/uefi-label" ]]; then
+			entry_label="$(cat "${KERNEL_INSTALL_CONF_ROOT}/uefi-label")"
+		fi
+	elif [[ -f /etc/default/uefi-label ]]; then
+		entry_label="$(cat /etc/default/uefi-label)"
+		einfo "Using kernel label from \"/etc/default/uefi-label\""
+	elif [[ -f /etc/kernel/uefi-label ]]; then
+		entry_label="$(cat /etc/kernel/uefi-label)"
+		einfo "Using kernel label from \"/etc/kernel/uefi-label\""
+	elif [[ -f /usr/lib/kernel/uefi-label ]]; then
+		entry_label="$(cat /usr/lib/kernel/uefi-label)"
+		einfo "Using kernel label from \"/usr/lib/kernel/uefi-label\""
 	else
-		entry_label="UMC $entry_label"
+		entry_label="${efi_file_path/.uefibackup} on $partition_label "
+		einfo "No uefi-label configuration file found!"
+
+		# Add prefix to entry label for easier identification
+		if [[ -n $backup_efi ]]; then
+			entry_label="UMCB $entry_label"
+		else
+			entry_label="UMC $entry_label"
+		fi
 	fi
+
+
+
 
 	# Create path to initramfs
 	local initramfs_image


### PR DESCRIPTION
Hey,

in some UEFIs the default Label may not be valid and therefor not displayed.
The user should have the option to specify a custom label.

This commit will allow uefi-mkconfig to parse file called uefi-label (searched for in the same paths as uefi-mkconfig) and use that label instead.