### PR TITLE
Add %kernel_release so CONFIG_LOCALVERSION can be in UEFI Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,11 @@ Following is a list of variables which could be used in entry label templates:
 
 1. `%efi_file_path` - Path to the efi file of the kernel
 2. `%partition_label` - Partition label of a partition on which the kernel image being added resides
-3. `%kernel_version` - Version of a kernel being added
-4. `%linux_name` - Distribution name of the syste
-5. `%entry_id` - ID of the entry being added (Recommended to avoid accidentally adding multiple entries with the same label)
-6. `%partition` - Partition on which the kernel image being added resides
+3. `%kernel_release` - Version of a kernel being added including localconfig suffix
+4. `%kernel_version` - Version of a kernel being added
+5. `%linux_name` - Distribution name of the syste
+6. `%entry_id` - ID of the entry being added (Recommended to avoid accidentally adding multiple entries with the same label)
+7. `%partition` - Partition on which the kernel image being added resides
 
 ### 7. Ignoring Kernel Images
 If needed, some kernel images can be ignored by creating an empty file in the same directory as the kernel with the same name

--- a/uefi-mkconfig
+++ b/uefi-mkconfig
@@ -19,6 +19,7 @@ add_uefi_entry () {
 	# Substitute %values in entry labels 
 	entry_label="${entry_label/\%efi_file_path/${efi_file_path/.uefibackup}}"
 	entry_label="${entry_label/\%partition_label/$partition_label}"
+	entry_label="${entry_label/\%kernel_release/$kernel_version}"
 	entry_label="${entry_label/\%kernel_version/${kernel_version/-*}}"
 	entry_label="${entry_label/\%linux_name/$NAME}"
 	entry_label="${entry_label/\%entry_id/$entry_id}"


### PR DESCRIPTION
/efc/default/uefi-mkconfig allows customizing the kernel names with KERNEL_CONFIG.

Adding the localversion suffix to available config options enabled the loading of multiple kernels of the same version, with differnet localversion. 

In my case, I have gentoo-kernel compiled from source on version 6.12.58 and gentoo-sources kernel on 6.12.58 also. My custom compiled kernel has the localconfig suffix set, which uname respects by appending it to the version number.

My current issue, is that when i use %kernel_version it doesn't let me differentiate between my two kernels on the uefi boot selection. In my case, they would both just say "x UMC Gentoo Linux (6.12.58)" instead of showing a difference.

Yes, I can use %efi_file_path but it makes the label long, and offscreen at first until it scrolls onto screen in my UI. I believe the localversion does a better job for this case.


With this merged, I can use this config to achieve my goal:
```
KERNEL_CONFIG="%entry_id %linux_name Linux %kernel_version;"
```
(the config change to /etc/default/uefi-mkconfig is not included in the pull request)


This is a forward patch of a working copy in the main tree.
